### PR TITLE
Fixed variable initialization bugs

### DIFF
--- a/setcolors.c
+++ b/setcolors.c
@@ -77,7 +77,7 @@ static int
 get_console_fd(const char *console_path)
 {
 	int i, fd;
-	char type = NULL;
+	char type = '\0';
 
 	// Use one of the default console paths
 	if ( ! console_path)
@@ -110,8 +110,8 @@ get_color_set_from_file(const char *file_path, char color_set[][7])
 {
 	int i;
 	FILE *fd;
-	char *line, *color = NULL;
-	size_t read;
+	char *line = NULL, *color = NULL;
+	size_t read = 0;
 
 	if ((fd = fopen(file_path, "r")) == NULL)
 		return -1;


### PR DESCRIPTION
Fixed a sporadic crash and a compilation warning.

`char type = NULL` is assigning a null pointer constant to a char, which compiles (sometimes with a warning) but is almost certainly not what you want. See http://c-faq.com/null/nullor0.html.

`getline` requires `*lineptr = NULL` and `n = 0` to trigger space allocation for `lineptr`. Omitting this initialization will sometimes prevent `getline` from calling `malloc` (depending on whatever happens to be in memory where `*n` is pointing), which makes `free()` below invalid. See http://man7.org/linux/man-pages/man3/getline.3.html and http://fxr.watson.org/fxr/source/libio/iogetdelim.c?v=GLIBC27;im=3#L65.
