### PR TITLE
Change getopt_long var to int to make -1 test work

### DIFF
--- a/setcolors.c
+++ b/setcolors.c
@@ -177,7 +177,7 @@ main(int argc, char *argv[])
 		{0, 0, 0, 0}
 	};
 
-	char c;
+	int c;
 	while((c = getopt_long(argc, argv, "-c:h", options, NULL)) != -1)
 	{
 		switch(c)


### PR DESCRIPTION
Changed the "c" var that takes getopt_long's result from char to int. On my box the test for -1 was failing. (This also matches the manpage for getopt_long.) For reference, this was on Linux 4.4.0 armv71 gcc 4.9.2, Debian 8.4 (Jessie)